### PR TITLE
Fix missing scanlines

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ function pointsToEdges(points: XYPoint[]) {
 function moveEdges(yScan: number, edges: Edge[], activeEdges: Edge[]) {
   // move active edges from edges to activeEdges
   // an active edge is one where either point is at yScan>=y
-  while (edges.length > 0 && yScan >= getYMin(edges[edges.length - 1])) { // !!! this assumes all the "active" edges are at the end of edges, otherwise it will miss some
+  while (edges.length > 0 && yScan >= getYMin(edges[edges.length - 1])) {
     activeEdges.push(edges.pop());
   }
 }
@@ -102,7 +102,6 @@ function getSpans(yScan: number, activeEdges: Edge[]) {
   // find spans of 'inside polygon' along scanline
   const spans: XYPoint[] = [];
   for (const edge of activeEdges) {
-    // !!! this looks like it's meant to get all the edge intersections along the scanline, but "active" edges don't necessarily intersect the scanline according to the definition above
     spans.push({ x: lerp(yScan, edge), y: yScan });
   }
   return spans;

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ function removeEdges(yScan: number, activeEdges: Edge[]) {
       // either one edge edge is on this scane line
       // or the entire edge is below yScan
       // remove offending edge and shrink array
-      
+
       if (i < activeEdges.length) {
         activeEdges.splice(i, 1);
         i -= 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ function pointsToEdges(points: XYPoint[]) {
 
 function moveEdges(yScan: number, edges: Edge[], activeEdges: Edge[]) {
   // move active edges from edges to activeEdges
-  // an active edge is one where either point is at y>=yScan
+  // an active edge is one where either point is at yScan>=y
   while (edges.length > 0 && yScan >= getYMin(edges[edges.length - 1])) { // !!! this assumes all the "active" edges are at the end of edges, otherwise it will miss some
     activeEdges.push(edges.pop());
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,23 +110,6 @@ function getSpans(yScan: number, activeEdges: Edge[]) {
   return spans;
 }
 
-function gatherSpans(spans: XYPoint[]): XYPoint[] {
-  // for a list of spans, gather all the pixels within those spans together
-  const gatheredSpans: XYPoint[][] = [];
-  for (let i = 0; i < spans.length; i += 2) {
-    const point1 = spans[i];
-    const point2 = spans[i + 1];
-    gatheredSpans.push([point1, point2]);
-  }
-  // !!! it looks like this algorithm pairs up all the points in spans, then flattens it, so the output should be the same as the input. put a print in to test this
-  const output = gatheredSpans.reduce(
-    (accumulator, value) => accumulator.concat(value),
-    []
-  );
-  console.log(spans, output);
-  return output
-}
-
 function slpfLines(points: XYPoint[]): XYPoint[][] {
   // Scanline Polygon Fill and return all points inside the polygon
   if (points.length < 3) return []; // need three points to do a fill
@@ -157,8 +140,7 @@ function slpfLines(points: XYPoint[]): XYPoint[][] {
       });
       // fill spans on scanline
       const spans = getSpans(yScan, activeEdges);
-        console.log(spans, gatherSpans(spans));
-      horizontalLines.push(gatherSpans(spans));
+      horizontalLines.push(spans);
       yScan += 1;
     } else {
       yScan += 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ function pointsToEdges(points: XYPoint[]) {
   for (let i = 0; i < points.length; i += 1) {
     const point2 = points[i];
     // ignore horizontal edges
-    if (point1.x !== point2.x) { // !!! surely this excludes vertical, not horizontal edges?
+    if (point1.y !== point2.y) {
       edges.push({ point1, point2 });
     }
     point1 = point2;

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ function getXofYMax(edge: Edge) {
 function pointsToEdges(points: XYPoint[]) {
   // converts list of points to list of non-horizontal edges
   const edges: Edge[] = [];
-  let point1 = points[points.length - 1]; // !!! why points.length - 1?
+  let point1 = points[points.length - 1]; // ensures that we get a closed loop of edges
   for (let i = 0; i < points.length; i += 1) {
     const point2 = points[i];
     // ignore horizontal edges
@@ -85,15 +85,13 @@ function moveEdges(yScan: number, edges: Edge[], activeEdges: Edge[]) {
 function removeEdges(yScan: number, activeEdges: Edge[]) {
   // remove inactive edges from activeEdges
   for (let i = 0; i < activeEdges.length; i += 1) {
-    if (yScan >= getYMax(activeEdges[i])) { // !!! by the earlier definition of an active edge, this should be yScan > getYMax
+    if (yScan > getYMax(activeEdges[i])) {
       // either one edge edge is on this scane line
       // or the entire edge is below yScan
       // remove offending edge and shrink array
-      // !!! this deletion mechanism is weird, normal way would be to use splice. I think this will fail if the final element is inactive
-      const last = activeEdges.pop();
-      if (i < activeEdges.length && last) {
-        // eslint-disable-next-line no-param-reassign
-        activeEdges[i] = last;
+      
+      if (i < activeEdges.length) {
+        activeEdges.splice(i, 1);
         i -= 1;
       }
     }


### PR DESCRIPTION
## Description

Occasionally we were getting blocks of missing scanlines in the filled shapes; turns out these were caused by vertical edges in the polygon, which were getting filtered instead of horizontal edges, and the algorithm skips any scanline with an odd number of edges crossing it. With a closed loop (which the algorithm enforces) the number of edges is even for all scanlines, but removing an edge makes it an open loop.

Also fixed a couple other things that might potentially have caused problems but were probably innocent in this case.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
